### PR TITLE
Fix orienation of FU in mochigoma

### DIFF
--- a/css/kifuforjs.css
+++ b/css/kifuforjs.css
@@ -96,6 +96,9 @@
 	display: none;
 	position: relative;
 }
+.kifuforjs div.mochi div.mochimain span.mochigoma div{
+	display: inline-block;
+}
 .kifuforjs div.mochi div.mochimain span.mochigoma.fu{
 	display: inline-block;
 	width: 120px;


### PR DESCRIPTION
Fix #34 

持ち駒の歩が2〜3枚の場合、他の駒と重なってしまうことがある問題を修正しました。
古いバージョンのKifu-for-JS v1.1.5だと、歩は横並びになっていたので、これに合わせる形で修正しました。

問題を再現するJKFファイル: [mochigoma.jkf.txt](https://github.com/na2hiro/Kifu-for-JS/files/1100801/mochigoma.jkf.txt)

## Before

<img width="591" alt="before-fix-mochigoma-orientation" src="https://user-images.githubusercontent.com/532251/27521287-15b83cd4-5a56-11e7-8411-324e66d1f116.png">

## After

<img width="587" alt="after-fix-mochigoma-orientation" src="https://user-images.githubusercontent.com/532251/27521288-15b8a6d8-5a56-11e7-8225-29c280c2ef65.png">
