### PR TITLE
fix webpack-dev-server v4 migration bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "test"
   },
   "scripts": {
-    "start": "npx webpack && webpack-dev-server --open example.html --mode development",
+    "start": "webpack-dev-server --open example.html --mode development",
     "ci": "run-s lint ci:build ci:test",
     "ci:start-server": "http-server . -p 8081",
     "ci:build": "npm run build -- --env ci",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "test"
   },
   "scripts": {
-    "start": "webpack-dev-server --open-page examples/example.html",
+    "start": "npx webpack && webpack-dev-server --open example.html --mode development",
     "ci": "run-s lint ci:build ci:test",
     "ci:start-server": "http-server . -p 8081",
     "ci:build": "npm run build -- --env ci",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,9 +73,20 @@ http://opensource.org/licenses/mit-license.php`
         }
     } else {
         common.devServer = {
-            progress: true,
             port: DEV_SERVER_PORT,
-            host: '0.0.0.0'
+            host: '0.0.0.0',
+            client: {
+                progress: true,
+            },
+            static: [
+                {
+                    directory: BUNDLE_DIR,
+                },
+                {
+                    directory: path.join(__dirname, "/examples"),
+                },
+            ],
+
         };
         common.devtool = "eval-cheap-module-source-map";
     }
@@ -112,7 +123,7 @@ http://opensource.org/licenses/mit-license.php`
         }
     });
 
-    return [bundle, bookmarklets];
+    return bundle;
 
     function getPublicPath() {
         if (IS_CI) {


### PR DESCRIPTION

## 関連するIssue

https://github.com/na2hiro/Kifu-for-JS/issues/70

## 背景

webpack-dev-serverの設定の3系→4系で、コードが変わっておりました。
それゆえ、` npm run start` で起動される開発サーバーが落ち、`examples/example.html` が表示されておりませんでした。


## 動作確認

![CleanShot 2022-09-22 at 09 45 35](https://user-images.githubusercontent.com/39001773/191634379-cd7fd02d-a226-44a1-9537-bfe2c956e692.gif)



